### PR TITLE
Add user_id column to tasks table

### DIFF
--- a/server/migrations/20240816162311_add_user_id_to_tasks_table.ts
+++ b/server/migrations/20240816162311_add_user_id_to_tasks_table.ts
@@ -1,0 +1,24 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .alterTable("tasks", function (table) {
+      table.integer("user_id").unsigned().nullable();
+      table.foreign("user_id").references("id").inTable("users").onDelete("CASCADE");
+    })
+    .then(async () => {
+      await knex("tasks").update({ user_id: 1 });
+    })
+    .then(async () => {
+      await knex.schema.alterTable("tasks", function (table) {
+        table.integer("user_id").unsigned().notNullable().alter();
+      });
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable("tasks", function (table) {
+    table.dropForeign("user_id");
+    table.dropColumn("user_id");
+  });
+}


### PR DESCRIPTION
This pull request adds a new column, `user_id`, to the `tasks` table in the migration file. The column is nullable and has a foreign key constraint referencing the `id` column in the `users` table with the `CASCADE` delete rule. The migration also updates the existing data in the `tasks` table by setting the `user_id` to 1 for all rows.